### PR TITLE
Add role name to meta file

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,3 @@ Author Information
 
 Tadej Janež
 
-Acknowledgement
----------------
-
-This Ansible role was originally developed for
-[Genialis](https://www.genialis.com). With approval from Genialis, the code was
-generalised and published as Open Source, for which the author would like to
-express his gratitude.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 galaxy_info:
+  role_name: update
   author: Tadej Janež
   description: Role to update and reboot (if necessary) Fedora, Red Hat/CentOS and Debian systems.
   # company: your company (optional)

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   role_name: update
-  author: Tadej Janež
+  author: Genialis
   description: Role to update and reboot (if necessary) Fedora, Red Hat/CentOS and Debian systems.
   # company: your company (optional)
   # If the issue tracker for your role is not on github, uncomment the


### PR DESCRIPTION
Issue: In Ansible Galaxy, the role is named "ansible_update_role" instead of "update".

Changes: updated configuration in meta/main.yml.